### PR TITLE
Update base_uri to new domain

### DIFF
--- a/src/Zoho/Subscriptions/Api.php
+++ b/src/Zoho/Subscriptions/Api.php
@@ -200,7 +200,7 @@ class Api extends ApiForge
         'zohoOrgId' => '',
         'tld' => 'com', // eu, in, com.au
         'client' => [
-            'base_uri' => 'https://subscriptions.zoho.{{tld}}/api/v1/',
+            'base_uri' => 'https://www.zohoapis.{{tld}}/billing/v1/',
             'verify' => false,
             'headers' => [
                 'Authorization' => 'Zoho-oauthtoken {{oauthtoken}}',


### PR DESCRIPTION
Zoho is updating their endpoints for all API calls from 1st June 2024: https://help.zoho.com/portal/en/community/topic/update-regarding-zoho-finance-applications-domain-for-api-users-2-2-2024

**Was:** 
subscriptions.zoho.com/api/v1

**Now:**
 www.zohoapis.com/billing/v1